### PR TITLE
p2p: fail cleanly when listen bind fails

### DIFF
--- a/node/src/core/transport.rs
+++ b/node/src/core/transport.rs
@@ -213,7 +213,16 @@ pub(crate) async fn event_loop(p2p: Arc<P2PManage>, mut worker: Worker) -> Rerr 
     let mut findnodes_tkr = new_ticker(52 * 60 * 4).await;
     let mut checkpeer_tkr = new_ticker(53 * 3).await;
     let mut boostndes_tkr = new_ticker(54 * 5).await;
-    let server_listener = p2p.server().await;
+    let server_listener = match p2p.server().await {
+        Ok(l) => l,
+        Err(ref e) => {
+            println!(
+                "\n[Error] p2p failed to bind port {}: {}\n",
+                p2p.cnf.listen, e
+            );
+            return errf!("p2p failed to bind port {}: {}", p2p.cnf.listen, e);
+        }
+    };
     let shutdown = p2p.shutdown.clone();
     loop {
         tokio::select! {

--- a/node/src/p2p/server.rs
+++ b/node/src/p2p/server.rs
@@ -1,10 +1,9 @@
 
 impl P2PManage {
 
-    pub(crate) async fn server(&self) -> TcpListener {
+    pub(crate) async fn server(&self) -> std::io::Result<TcpListener> {
         let port = self.cnf.listen;
-        let listener = TcpListener::bind( format!("0.0.0.0:{}", port) ).await.unwrap();
-        listener
+        TcpListener::bind(format!("0.0.0.0:{}", port)).await
     }
 
 }


### PR DESCRIPTION
## what was wrong

the http api server already checks `TcpListener::bind` and prints an error if the port cannot be opened. the p2p listener did `.unwrap()` on the same operation, so a busy port or other bind error crashed the whole process with a panic.

## what changed

- `P2PManage::server` now returns `io::Result` instead of panicking.
- `event_loop` prints a clear message and returns `errf!` like the api server path, so operators get a normal shutdown path instead of a thread panic.

this matches the behavior of `server_listen` in the `server` crate.

---
made by mooncitydev