### PR TITLE
Cap collection preallocation

### DIFF
--- a/field/src/combi/dynlist.rs
+++ b/field/src/combi/dynlist.rs
@@ -42,7 +42,7 @@ impl Parse for $class {
         let mut seek = count.parse_from(buf)?;
         let count_usize = *count as usize;
         let mut cur = *buf;
-        let mut new_vlist = Vec::with_capacity(count_usize);
+        let mut new_vlist = Vec::with_capacity($crate::prealloc_cap(count_usize, cur.len()));
         for _ in 0..count_usize {
             let (obj, mvsk) = $createfn(cur)?;
             cur = &cur[mvsk..];

--- a/field/src/combi/dynvec.rs
+++ b/field/src/combi/dynvec.rs
@@ -33,7 +33,7 @@ impl Parse for $class {
         let mut seek = 0;
         let count = *self.count as usize;
         let mut cur = *buf;
-        let mut new_vlist = Vec::with_capacity(count);
+        let mut new_vlist = Vec::with_capacity($crate::prealloc_cap(count, cur.len()));
         for _ in 0..count {
             let (obj, mvsk) = $parseobjfunc(cur)?;
             cur = &cur[mvsk..];

--- a/field/src/combi/list.rs
+++ b/field/src/combi/list.rs
@@ -46,7 +46,7 @@ impl Parse for $class {
         let mut count = <$cty>::default();
         let mut seek = count.parse_from(buf)?;
         let count_usize = *count as usize;
-        let mut new_lists = Vec::with_capacity(count_usize);
+        let mut new_lists = Vec::with_capacity($crate::prealloc_cap(count_usize, buf.len()));
         for _ in 0..count_usize {
             let mut obj = <$vty>::new();
             seek += obj.parse_from(buf)?;

--- a/field/src/core/diamond.rs
+++ b/field/src/core/diamond.rs
@@ -192,7 +192,7 @@ macro_rules! define_diamond_name_list {
             fn parse_from(&mut self, buf: &mut &[u8]) -> Ret<usize> {
                 let mut count = <$nty>::default();
                 let mut seek = count.parse_from(buf)?;
-                let mut lists = Vec::with_capacity(*count as usize);
+                let mut lists = Vec::with_capacity($crate::prealloc_cap(*count as usize, buf.len()));
                 for _ in 0..*count as usize {
                     let mut obj = DiamondName::new();
                     seek += obj.parse_from(buf)?;

--- a/field/src/util.rs
+++ b/field/src/util.rs
@@ -13,4 +13,34 @@ macro_rules! impl_field_only_new {
 }
 
 
+/// Safe initial capacity for parsing a length-prefixed collection from an
+/// untrusted buffer. Caps `count` at `remaining_bytes` to stop a forged length
+/// prefix from triggering an enormous allocation.
+/// * `count` — element count read from the wire
+/// * `remaining_bytes` — bytes left to parse
+#[inline]
+pub fn prealloc_cap(count: usize, remaining_bytes: usize) -> usize {
+    count.min(remaining_bytes)
+}
+
+#[cfg(test)]
+mod prealloc_cap_tests {
+    use super::prealloc_cap;
+
+    #[test]
+    fn caps_oversized_count_to_remaining_bytes() {
+        // Fake count with a tiny body must not preallocate by `count`
+        assert_eq!(prealloc_cap(u32::MAX as usize, 8), 8);
+        assert_eq!(prealloc_cap(usize::MAX, 0), 0);
+    }
+
+    #[test]
+    fn keeps_count_for_legitimate_input() {
+        // A valid count (<= remaining bytes) is returned unchanged.
+        assert_eq!(prealloc_cap(3, 90), 3);
+        assert_eq!(prealloc_cap(10, 10), 10);
+    }
+}
+
+
 

--- a/protocol/src/tests.rs
+++ b/protocol/src/tests.rs
@@ -2403,3 +2403,32 @@ fn test_address_bare_base58check_in_protocol() {
     ptr.from_json(&format!(r#""{}""#, addr_str)).unwrap();
     assert_eq!(ptr.to_readable(), addr_str);
 }
+
+#[test]
+fn test_block_parse_rejects_oversized_transaction_count_without_oom() {
+    // Regression test for transactions preallocation DoS
+    let _guard = install_test_registry();
+
+    // Build a block whose body holds exactly one parseable transaction.
+    let mut block = BlockV1::default();
+    block.intro.head.height = BlockHeight::from(1);
+    let mut tx = TransactionType2::default();
+    tx.ty = Uint1::from(TransactionType2::TYPE);
+    tx.timestamp = Timestamp::from(1730000001);
+    tx.fee = Amount::mei(1);
+    let mut act = HacToTrs::new();
+    act.to = AddrOrPtr::from_addr(field::ADDRESS_ONEX.clone());
+    act.hacash = Amount::small(1, 244);
+    tx.actions.push(Box::new(act)).unwrap();
+    block.transactions.push(Box::new(tx)).unwrap();
+
+    // Lie about the count: claim u32::MAX transactions while the body has one.
+    block.intro.head.transaction_count = Uint4::from(u32::MAX);
+
+    let bytes = block.serialize();
+    let res = block_create(&bytes);
+    assert!(
+        res.is_err(),
+        "block with an oversized transaction_count must be rejected by the parser"
+    );
+}


### PR DESCRIPTION
## Problem

The length-prefixed collection parsers called `Vec::with_capacity(count)` with `count` read straight from untrusted input.
```
`receive_blocks` → `synchronize` → `block_create`
```
A block header carries `transaction_count` as a `Uint4`, so a peer could send a tiny `MSG_BLOCK` claiming `0xFFFFFFFF` transactions and force a ~64 GB allocation. Causing process abort and crashing the node.

## Fix

Cap the initial capacity by the remaining byte count (each element is ≥1 byte, so a valid `count` never exceeds it):

```rust
pub fn prealloc_cap(count: usize, remaining_bytes: usize) -> usize {
    count.min(remaining_bytes)
}
```

Malicious blocks now fail with "parse error" instead of aborting.

### Tests
 - Field: 84/84 including new `prealloc_cap_tests`
 - Protocol: 85/85 including  block regression test
 - Cargo check OK