### PR TITLE
HIP-25 HACD staking port (draft, actions 37/38)

### DIFF
--- a/basis/src/component/env.rs
+++ b/basis/src/component/env.rs
@@ -5,6 +5,8 @@ pub struct ChainInfo {
     pub id: u32,
     pub fast_sync: bool,
     pub diamond_form: bool,
+    /// HIP-25: 0 = disabled until on-chain `StakingGlobal.activation_height` or this value is set in config.
+    pub staking_activation_height: u64,
 }
 
 

--- a/basis/src/config/engine.rs
+++ b/basis/src/config/engine.rs
@@ -46,6 +46,8 @@ pub struct EngineConf {
     // VM contract cache (performance-only, consensus-neutral)
     // Unit: MB. `0` disables cache.
     pub contract_cache_size: f64,
+    /// HIP-25: mainnet fork height; 0 = disabled.
+    pub staking_activation_height: u64,
 }
 
 
@@ -125,6 +127,7 @@ impl EngineConf {
             txpool_maxs: Vec::default(),
             // vm cache
             contract_cache_size: 0.0,
+            staking_activation_height: 0,
         };
         // setup lowest_fee
         if ini_must(sec_server, "lowest_fee", "").len() > 0 {
@@ -142,6 +145,7 @@ impl EngineConf {
         cnf.sync_maxh = ini_must_u64(sec_mint, "height_max", 0);
         cnf.dev_count_switch = ini_must_u64(sec_mint, "dev_count_switch", 0) as usize;
         cnf.show_miner_name = ini_must_bool(sec_mint, "show_miner_name", false);
+        cnf.staking_activation_height = ini_must_u64(sec_mint, "staking_activation_height", 0);
 
         let sec_vm = &ini_section(ini, "vm");
         cnf.vm_log_enable = ini_must_bool(sec_vm, "log_enable", false);

--- a/chain/src/check.rs
+++ b/chain/src/check.rs
@@ -30,6 +30,7 @@ fn try_execute_tx_by_author(
             id: this.cnf.chain_id,
             diamond_form: this.cnf.diamond_form,
             fast_sync: false,
+            staking_activation_height: this.cnf.staking_activation_height,
         },
         block: BlkInfo {
             height: pd_hei,

--- a/chain/src/insert.rs
+++ b/chain/src/insert.rs
@@ -111,6 +111,7 @@ fn insert_by(eng: &ChainEngine, tree: &mut Roller, mut blk: BlkPkg) -> Ret<Inser
         fast_sync,
         diamond_form: eng.cnf.diamond_form,
         id: eng.cnf.chain_id,
+        staking_activation_height: eng.cnf.staking_activation_height,
     };
 
     let logs = Box::new(eng.logs.next(maybe!(is_open_vmlog(eng, height), height, 0)));

--- a/doc/HIP25.md
+++ b/doc/HIP25.md
@@ -1,0 +1,52 @@
+# HIP-25 HACD Staking (fullnodedev draft)
+
+**Status:** Port in progress on branch `hip-25-port-draft`  
+**Reference implementation:** https://github.com/Moskyera/rust/tree/hip-25-staking @ `v0.1.0-hip25-reference`  
+**Spec:** https://github.com/Moskyera/rust/blob/hip-25-staking/docs/HIP25_SPEC.md
+
+## Action kind mapping (important)
+
+Legacy `hacash/rust` fork used kinds **34/35** for stake/unstake.  
+**fullnodedev already assigns:**
+
+| Kind | Action |
+|------|--------|
+| 34 | DiaInscEdit (HIP-22) |
+| 35 | DiaInscMove |
+| 36 | DiaInscDrop |
+
+HIP-25 on fullnodedev uses **37 = DiaStake**, **38 = DiaUnstake**.
+
+## Diamond status
+
+| Value | Meaning |
+|-------|---------|
+| 4 | Staked |
+| 5 | Staking cooldown |
+
+## Economics (v3)
+
+Redirect **10% DiamondMint `fee_got`** to staking pool when active.  
+Inscription fees remain 100% burn. See reference `docs/HIP25_ECONOMICS_V3.md`.
+
+## Config
+
+```ini
+[mint]
+staking_activation_height = 0
+```
+
+`0` = disabled until community agrees a fork height.
+
+## Port phases
+
+| Phase | Scope | Status |
+|-------|--------|--------|
+| 1 | Types, actions 37/38, stake/unstake core | Done |
+| 2 | Block-close rewards + miner-share redirect | Done |
+| 3 | RPC `/query/staking/*` | TODO |
+| 4 | Tests ported from reference | TODO |
+
+## Maintainer note
+
+Draft PR for review — not activated on mainnet. Coordinate with Istanbul (765432) timing.

--- a/field/src/core/diamond_smelt.rs
+++ b/field/src/core/diamond_smelt.rs
@@ -5,6 +5,10 @@
 pub const DIAMOND_STATUS_NORMAL                : Uint1 = Uint1::from(1);
 pub const DIAMOND_STATUS_LENDING_TO_SYSTEM     : Uint1 = Uint1::from(2);
 pub const DIAMOND_STATUS_LENDING_TO_USER       : Uint1 = Uint1::from(3);
+/// HIP-25: locked and earning rewards
+pub const DIAMOND_STATUS_STAKED                : Uint1 = Uint1::from(4);
+/// HIP-25: post-unstake cooldown until unlock_height
+pub const DIAMOND_STATUS_STAKING_COOLDOWN      : Uint1 = Uint1::from(5);
 
 
 /*

--- a/field/src/core/staking.rs
+++ b/field/src/core/staking.rs
@@ -1,0 +1,84 @@
+/// HIP-25 staking constants and on-chain types (v3 economics).
+
+pub const STAKING_FEE_SHARE_PERCENT: u64 = 10;
+pub const STAKING_POOL_SWEEP_BLOCKS: u64 = 1008;
+pub const COOLDOWN_BLOCKS: u64 = 864;
+pub const MIN_STAKE_BLOCKS: u64 = 25714;
+
+pub const STAKING_EVENT_STAKED: Uint1 = Uint1::from(1);
+pub const STAKING_EVENT_UNSTAKE_REQUESTED: Uint1 = Uint1::from(2);
+pub const STAKING_EVENT_UNSTAKED: Uint1 = Uint1::from(3);
+pub const STAKING_EVENT_REWARD_DISTRIBUTED: Uint1 = Uint1::from(4);
+pub const STAKING_EVENT_POOL_SWEPT: Uint1 = Uint1::from(5);
+
+#[inline]
+pub fn diamond_status_allows_transfer(status: &Uint1) -> bool {
+    *status == DIAMOND_STATUS_NORMAL
+}
+
+#[inline]
+pub fn diamond_status_allows_inscription(status: &Uint1) -> bool {
+    *status == DIAMOND_STATUS_NORMAL
+}
+
+#[inline]
+pub fn diamond_status_is_staking_locked(status: &Uint1) -> bool {
+    *status == DIAMOND_STATUS_STAKED || *status == DIAMOND_STATUS_STAKING_COOLDOWN
+}
+
+combi_struct! { StakingGlobal,
+    total_staked_shares : Uint5
+    global_reward_index : Uint8
+    reward_pool_zhu     : Uint8
+    paused              : Uint1
+    unlock_queue_head   : Uint5
+    unlock_queue_tail   : Uint5
+    activation_height   : BlockHeight
+    event_log_tail      : Uint5
+    cumulative_deposit_zhu : Uint8
+    cumulative_paid_zhu    : Uint8
+    cumulative_pool_burned_zhu : Uint8
+    zero_staker_blocks     : Uint5
+}
+
+impl StakingGlobal {
+    pub fn is_paused(&self) -> bool {
+        self.paused.uint() != 0
+    }
+
+    pub fn is_active_at(&self, height: u64, configured_activation: u64) -> bool {
+        let act = self.activation_height.uint();
+        let threshold = if act > 0 { act } else { configured_activation };
+        threshold > 0 && height >= threshold
+    }
+}
+
+combi_struct! { StakingRecord,
+    stake_height   : BlockHeight
+    unlock_height  : BlockHeight
+    reward_index   : Uint8
+    pending_reward : Amount
+}
+
+impl StakingRecord {
+    pub fn is_active_stake(&self) -> bool {
+        self.unlock_height.uint() == 0
+    }
+}
+
+combi_struct! { StakingUnlockEntry,
+    unlock_height : BlockHeight
+    diamond       : DiamondName
+    staker        : Address
+    reward        : Amount
+}
+
+combi_struct! { StakingEvent,
+    kind          : Uint1
+    height        : BlockHeight
+    diamond       : DiamondName
+    staker        : Address
+    unlock_height : BlockHeight
+    reward        : Amount
+    shares        : Uint5
+}

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -52,6 +52,7 @@ include! {"core/amount.rs"}
 include! {"core/wire_amount.rs"}
 include! {"core/diamond.rs"}
 include! {"core/diamond_smelt.rs"}
+include! {"core/staking.rs"}
 include! {"core/status.rs"}
 include! {"core/asset.rs"}
 

--- a/mint/src/action/diamond_insc.rs
+++ b/mint/src/action/diamond_insc.rs
@@ -78,11 +78,19 @@ fn load_diamond_for_inscription(state: &mut CoreState, diamond: &DiamondName) ->
         state.diamond(diamond)
     );
     check_inscription_owner_privakey(&diasto.address, diamond)?;
-    if diasto.status != DIAMOND_STATUS_NORMAL {
-        return errf!(
-            "diamond {} has been mortgaged and cannot operate inscription",
-            diamond.to_readable()
-        );
+    if !diamond_status_allows_inscription(&diasto.status) {
+        let msg = if diamond_status_is_staking_locked(&diasto.status) {
+            format!(
+                "diamond {} is staked or in staking cooldown and cannot operate inscription",
+                diamond.to_readable()
+            )
+        } else {
+            format!(
+                "diamond {} has been mortgaged and cannot operate inscription",
+                diamond.to_readable()
+            )
+        };
+        return errf!("{}", msg);
     }
     Ok(diasto)
 }

--- a/mint/src/action/diamond_staking.rs
+++ b/mint/src/action/diamond_staking.rs
@@ -1,0 +1,50 @@
+// HIP-25: Diamond Stake / Unstake (kinds 37 / 38 on fullnodedev).
+
+action_define! { DiaStake, 37,
+    ActScope::TOP, 2, false, [],
+    {
+        diamonds : DiamondNameListMax200
+    },
+    (self, {
+        let a = self;
+        format!("Stake {} HACD ({})", a.diamonds.length(), a.diamonds.splitstr())
+    }),
+    (self, ctx, _gas {
+        diamond_stake(self, ctx)
+    })
+}
+
+action_define! { DiaUnstake, 38,
+    ActScope::TOP, 2, false, [],
+    {
+        diamonds : DiamondNameListMax200
+    },
+    (self, {
+        let a = self;
+        format!("Unstake {} HACD ({})", a.diamonds.length(), a.diamonds.splitstr())
+    }),
+    (self, ctx, _gas {
+        diamond_unstake(self, ctx)
+    })
+}
+
+fn diamond_stake(this: &DiaStake, ctx: &mut dyn Context) -> XRet<Vec<u8>> {
+    let env = ctx.env().clone();
+    let staker = env.tx.main;
+    ctx.check_sign(&staker)?;
+    let height = env.block.height;
+    let activation = env.chain.staking_activation_height;
+    let mut state = CoreState::wrap(ctx.state());
+    staking_apply_stake(&mut state, &staker, &this.diamonds, height, activation)?;
+    Ok(vec![])
+}
+
+fn diamond_unstake(this: &DiaUnstake, ctx: &mut dyn Context) -> XRet<Vec<u8>> {
+    let env = ctx.env().clone();
+    let staker = env.tx.main;
+    ctx.check_sign(&staker)?;
+    let height = env.block.height;
+    let mut state = CoreState::wrap(ctx.state());
+    staking_apply_unstake(&mut state, &staker, &this.diamonds, height)?;
+    Ok(vec![])
+}

--- a/mint/src/action/mod.rs
+++ b/mint/src/action/mod.rs
@@ -17,6 +17,7 @@ include! {"channel.rs"}
 include! {"diamond_util.rs"}
 include! {"diamond_mint.rs"}
 include! {"diamond_insc.rs"}
+include! {"diamond_staking.rs"}
 include! {"asset.rs"}
 include! {"util.rs"}
 
@@ -46,5 +47,9 @@ action_register! {
     DiaInscMove
     DiaInscDrop
     DiaInscEdit
+
+    // HIP-25 staking
+    DiaStake
+    DiaUnstake
 
 }

--- a/protocol/src/block/mod.rs
+++ b/protocol/src/block/mod.rs
@@ -6,6 +6,7 @@ use field::*;
 
 use super::context;
 use super::operate;
+use super::state::CoreState;
 use super::transaction::*;
 
 include! {"util.rs"}

--- a/protocol/src/block/v1.rs
+++ b/protocol/src/block/v1.rs
@@ -97,15 +97,31 @@ impl BlockExec for BlockV1 {
         let mut ctxobj = context::ContextInst::new(env, state, logs, ptx);
         let ctx = &mut ctxobj;
         let txs = self.transactions();
-        let mut total_fee = Amount::zero();
+        let height = self.height().uint();
+        let activation = ctx.env().chain.staking_activation_height;
+        let mut miner_fee = Amount::zero();
         // exec each tx
         for tx in txs {
             ctx.reset_for_new_tx(tx.as_read());
             tx.execute(ctx)?; // do exec
-            total_fee = total_fee.add_mode_u64(&tx.fee_got())?; // add fee
+            let fee = tx.fee_got();
+            if fee.is_positive() {
+                let mut state = CoreState::wrap(ctx.state());
+                let redirect = operate::staking_is_active_at_height(&state, height, activation)
+                    && operate::staking_tx_qualifies_for_mint_fee_redirect(tx.as_read());
+                if redirect {
+                    operate::staking_deposit_mint_miner_share(&mut state, &fee);
+                } else {
+                    miner_fee = miner_fee.add_mode_u64(&fee)?;
+                }
+            }
         }
-        if let Some(fee_receiver) = fee_receiver.filter(|_| total_fee.is_positive()) {
-            operate::hac_add(ctx, &fee_receiver, &total_fee)?;
+        if let Some(fee_receiver) = fee_receiver.filter(|_| miner_fee.is_positive()) {
+            operate::hac_add(ctx, &fee_receiver, &miner_fee)?;
+        }
+        {
+            let mut state = CoreState::wrap(ctx.state());
+            operate::staking_on_block_close(&mut state, height, activation)?;
         }
         Ok(ctxobj.release())
 

--- a/protocol/src/operate/diamond.rs
+++ b/protocol/src/operate/diamond.rs
@@ -97,8 +97,19 @@ pub fn check_diamond_status(state: &mut CoreState, addr_from: &Address, hacd_nam
     let Some(diaitem) = state.diamond(hacd_name) else {
         return xerrf!("diamond status {} not found", hacd_name.to_readable());
     };
-    if diaitem.status != DIAMOND_STATUS_NORMAL {
-        return xerr_rf!("diamond {} has been mortgaged and cannot be transferred", hacd_name.to_readable())
+    if !diamond_status_allows_transfer(&diaitem.status) {
+        let msg = if diamond_status_is_staking_locked(&diaitem.status) {
+            format!(
+                "diamond {} is staked or in staking cooldown and cannot be transferred",
+                hacd_name.to_readable()
+            )
+        } else {
+            format!(
+                "diamond {} has been mortgaged and cannot be transferred",
+                hacd_name.to_readable()
+            )
+        };
+        return xerr_rf!("{}", msg);
     }
     if *addr_from != diaitem.address {
         return xerr_rf!("diamond {} does not belong to address {}", hacd_name.to_readable(), addr_from)

--- a/protocol/src/operate/hacash.rs
+++ b/protocol/src/operate/hacash.rs
@@ -88,6 +88,20 @@ pub fn hac_check(ctx: &mut dyn Context, addr: &Address, amt: &Amount) -> XRet<Am
 }
 
 
+/// Credit HAC balance without Context (block-close / internal settlement).
+pub fn hac_add_balance(state: &mut CoreState, addr: &Address, amt: &Amount) -> XRet<()> {
+    check_amount_is_positive!(amt);
+    addr.check_version()?;
+    let mut bls = state.balance(addr).unwrap_or_default();
+    bls.hacash = bls.hacash.add_mode_u128(amt)?;
+    bls.hacash.check_store_long()?;
+    state.balance_set(addr, &bls);
+    if blackhole_engulf(state, addr) {
+        total_record_blackhole_hac(state, amt)?;
+    }
+    Ok(())
+}
+
 pub fn hac_add(ctx: &mut dyn Context, addr: &Address, amt: &Amount) -> XRet<Vec<u8>> {
     check_amount_is_positive!(amt);
     do_hac_add(ctx, addr, amt)?;

--- a/protocol/src/operate/mod.rs
+++ b/protocol/src/operate/mod.rs
@@ -11,4 +11,5 @@ include! {"hacash.rs"}
 include! {"diamond.rs"}
 include! {"satoshi.rs"}
 include! {"asset.rs"}
+include! {"staking.rs"}
 // include!{"channel.rs"}

--- a/protocol/src/operate/staking.rs
+++ b/protocol/src/operate/staking.rs
@@ -1,0 +1,409 @@
+/// HIP-25 staking operations (v3 economics, CoreState).
+
+const DIAMOND_MINT_ACTION_KIND: u16 = 4;
+
+fn staking_accrued_amount(global_index: &Uint8, snapshot: &Uint8) -> Ret<Amount> {
+    let zhu = global_index.uint().saturating_sub(snapshot.uint());
+    if zhu == 0 {
+        return Ok(Amount::default());
+    }
+    Ok(Amount::zhu(zhu))
+}
+
+pub fn staking_is_active_at_height(state: &CoreState<'_>, height: u64, configured_activation: u64) -> bool {
+    state.get_staking_global().is_active_at(height, configured_activation)
+}
+
+/// True when tx fee miner share should fund the staking pool (DiamondMint bid only).
+pub fn staking_tx_qualifies_for_mint_fee_redirect(tx: &dyn TransactionRead) -> bool {
+    tx.actions()
+        .iter()
+        .any(|a| a.kind() == DIAMOND_MINT_ACTION_KIND && a.extra9())
+}
+
+pub fn staking_deposit_fee(state: &mut CoreState<'_>, fee_zhu: u64) {
+    if fee_zhu == 0 {
+        return;
+    }
+    let mut global = state.get_staking_global();
+    global.reward_pool_zhu = Uint8::from(global.reward_pool_zhu.uint() + fee_zhu);
+    global.cumulative_deposit_zhu =
+        Uint8::from(global.cumulative_deposit_zhu.uint() + fee_zhu);
+    state.set_staking_global(&global);
+}
+
+pub fn staking_deposit_mint_miner_share(state: &mut CoreState<'_>, fee: &Amount) {
+    if !fee.is_positive() {
+        return;
+    }
+    let zhu = fee.to_zhu_u64().unwrap_or(0);
+    staking_deposit_fee(state, zhu);
+}
+
+fn staking_push_event(state: &mut CoreState<'_>, event: &StakingEvent) {
+    let mut global = state.get_staking_global();
+    let id = global.event_log_tail.uint();
+    state.staking_event_set(&Uint5::from(id), event);
+    global.event_log_tail = Uint5::from(id + 1);
+    state.set_staking_global(&global);
+}
+
+pub fn staking_sweep_idle_pool(state: &mut CoreState<'_>, height: u64) -> XRet<()> {
+    let mut global = state.get_staking_global();
+    let shares = global.total_staked_shares.uint();
+    let pool = global.reward_pool_zhu.uint();
+    if shares > 0 || pool == 0 {
+        global.zero_staker_blocks = Uint5::from(0);
+        state.set_staking_global(&global);
+        return Ok(());
+    }
+    let idle = global.zero_staker_blocks.uint() + 1;
+    global.zero_staker_blocks = Uint5::from(idle);
+    if idle < STAKING_POOL_SWEEP_BLOCKS {
+        state.set_staking_global(&global);
+        return Ok(());
+    }
+    global.reward_pool_zhu = Uint8::from(0);
+    global.zero_staker_blocks = Uint5::from(0);
+    global.cumulative_pool_burned_zhu =
+        Uint8::from(global.cumulative_pool_burned_zhu.uint() + pool);
+    state.set_staking_global(&global);
+    let burn_amt = Amount::zhu(pool);
+    with_total_count(state, |ttcount| {
+        total_add_amount_238(
+            &mut ttcount.hacd_bid_burn_238,
+            &burn_amt,
+            "hacd_bid_burn_238",
+        )
+    })?;
+    staking_push_event(
+        state,
+        &StakingEvent {
+            kind: STAKING_EVENT_POOL_SWEPT,
+            height: BlockHeight::from(height),
+            diamond: DiamondName::default(),
+            staker: Address::default(),
+            unlock_height: BlockHeight::from(0),
+            reward: burn_amt,
+            shares: Uint5::from(0),
+        },
+    );
+    Ok(())
+}
+
+pub fn staking_distribute_rewards(state: &mut CoreState<'_>, height: u64) -> XRet<()> {
+    let mut global = state.get_staking_global();
+    let shares = global.total_staked_shares.uint();
+    let pool = global.reward_pool_zhu.uint();
+    if shares == 0 || pool == 0 {
+        return Ok(());
+    }
+    let increment = pool / shares;
+    if increment > 0 {
+        global.global_reward_index =
+            Uint8::from(global.global_reward_index.uint() + increment);
+    }
+    let distributed = increment * shares;
+    if distributed >= pool {
+        global.reward_pool_zhu = Uint8::from(0);
+    } else {
+        global.reward_pool_zhu = Uint8::from(pool - distributed);
+    }
+    state.set_staking_global(&global);
+    if distributed > 0 {
+        staking_push_event(
+            state,
+            &StakingEvent {
+                kind: STAKING_EVENT_REWARD_DISTRIBUTED,
+                height: BlockHeight::from(height),
+                diamond: DiamondName::default(),
+                staker: Address::default(),
+                unlock_height: BlockHeight::from(0),
+                reward: Amount::zhu(distributed),
+                shares: Uint5::from(shares),
+            },
+        );
+    }
+    Ok(())
+}
+
+fn staking_enqueue_unlock(state: &mut CoreState<'_>, entry: &StakingUnlockEntry) -> XRet<()> {
+    let mut global = state.get_staking_global();
+    let id = global.unlock_queue_tail.uint();
+    state.staking_unlock_set(&Uint5::from(id), entry);
+    global.unlock_queue_tail = Uint5::from(id + 1);
+    state.set_staking_global(&global);
+    Ok(())
+}
+
+fn staking_finalize_unlock(state: &mut CoreState<'_>, entry: &StakingUnlockEntry) -> XRet<()> {
+    let dianame = &entry.diamond;
+    let mut diaitem = match state.diamond(dianame) {
+        Some(d) => d,
+        None => {
+            return xerrf!("diamond {} not found", dianame.to_readable());
+        }
+    };
+    if diaitem.status != DIAMOND_STATUS_STAKING_COOLDOWN {
+        return xerrf!(
+            "diamond {} unlock failed: expected cooldown status",
+            dianame.to_readable()
+        );
+    }
+    diaitem.status = DIAMOND_STATUS_NORMAL;
+    state.diamond_set(dianame, &diaitem);
+    state.staking_record_del(dianame);
+    staking_push_event(
+        state,
+        &StakingEvent {
+            kind: STAKING_EVENT_UNSTAKED,
+            height: entry.unlock_height.clone(),
+            diamond: entry.diamond.clone(),
+            staker: entry.staker.clone(),
+            unlock_height: entry.unlock_height.clone(),
+            reward: entry.reward.clone(),
+            shares: Uint5::from(0),
+        },
+    );
+    Ok(())
+}
+
+pub fn staking_process_unlock_queue(state: &mut CoreState<'_>, height: u64) -> XRet<()> {
+    let mut pending: Vec<(Uint5, StakingUnlockEntry)> = Vec::new();
+    let mut global = state.get_staking_global();
+    let mut head = global.unlock_queue_head.uint();
+    let tail = global.unlock_queue_tail.uint();
+    while head < tail {
+        let key = Uint5::from(head);
+        let entry = match state.staking_unlock(&key) {
+            Some(e) => e,
+            None => {
+                return xerrf!(
+                    "staking unlock queue corrupted: missing entry {} (head {} tail {})",
+                    head,
+                    head,
+                    tail
+                );
+            }
+        };
+        if entry.unlock_height.uint() > height {
+            break;
+        }
+        pending.push((key, entry));
+        head += 1;
+    }
+    global.unlock_queue_head = Uint5::from(head);
+    state.set_staking_global(&global);
+
+    for (key, entry) in pending {
+        let reward = entry.reward.clone();
+        let staker = entry.staker.clone();
+        if reward.is_positive() {
+            hac_add_balance(state, &staker, &reward)?;
+            let mut global = state.get_staking_global();
+            let paid = reward.to_zhu_u64().unwrap_or(0);
+            global.cumulative_paid_zhu =
+                Uint8::from(global.cumulative_paid_zhu.uint() + paid);
+            state.set_staking_global(&global);
+        }
+        staking_finalize_unlock(state, &entry)?;
+        state.staking_unlock_del(&key);
+    }
+    Ok(())
+}
+
+pub fn staking_on_block_close(
+    state: &mut CoreState<'_>,
+    height: u64,
+    configured_activation: u64,
+) -> XRet<()> {
+    if !staking_is_active_at_height(state, height, configured_activation) {
+        return Ok(());
+    }
+    staking_sweep_idle_pool(state, height)?;
+    staking_distribute_rewards(state, height)?;
+    staking_process_unlock_queue(state, height)?;
+    Ok(())
+}
+
+pub fn check_diamond_stakeable(
+    state: &CoreState<'_>,
+    staker: &Address,
+    hacd_name: &DiamondName,
+) -> XRet<DiamondSto> {
+    let diaitem = match state.diamond(hacd_name) {
+        Some(d) => d,
+        None => {
+            return xerrf!("diamond {} not found", hacd_name.to_readable());
+        }
+    };
+    if !diamond_status_allows_transfer(&diaitem.status) {
+        let msg = if diamond_status_is_staking_locked(&diaitem.status) {
+            format!(
+                "diamond {} cannot be staked while status is {} (staking locked)",
+                hacd_name.to_readable(),
+                diaitem.status.uint()
+            )
+        } else {
+            format!(
+                "diamond {} cannot be staked while status is {}",
+                hacd_name.to_readable(),
+                diaitem.status.uint()
+            )
+        };
+        return xerrf!("{}", msg);
+    }
+    if *staker != diaitem.address {
+        return xerrf!(
+            "diamond {} not belong to address {}",
+            hacd_name.to_readable(),
+            staker
+        );
+    }
+    Ok(diaitem)
+}
+
+pub fn staking_set_paused(state: &mut CoreState<'_>, paused: bool) {
+    let mut global = state.get_staking_global();
+    global.paused = Uint1::from(if paused { 1 } else { 0 });
+    state.set_staking_global(&global);
+}
+
+pub fn staking_apply_stake(
+    state: &mut CoreState<'_>,
+    staker: &Address,
+    diamonds: &DiamondNameListMax200,
+    height: u64,
+    configured_activation: u64,
+) -> XRet<()> {
+    diamonds.check()?;
+    let mut global = state.get_staking_global();
+    if !global.is_active_at(height, configured_activation) {
+        return xerrf!("HACD staking is not active at height {}", height);
+    }
+    if global.is_paused() {
+        return xerrf!("HACD staking is paused");
+    }
+    let reward_index = global.global_reward_index.clone();
+
+    for dianame in diamonds.clone().into_iter() {
+        let mut diaitem = check_diamond_stakeable(state, staker, &dianame)?;
+        diaitem.status = DIAMOND_STATUS_STAKED;
+        state.diamond_set(&dianame, &diaitem);
+
+        let record = StakingRecord {
+            stake_height: BlockHeight::from(height),
+            unlock_height: BlockHeight::from(0),
+            reward_index: reward_index.clone(),
+            pending_reward: Amount::default(),
+        };
+        state.staking_record_set(&dianame, &record);
+        global.total_staked_shares = Uint5::from(global.total_staked_shares.uint() + 1);
+
+        staking_push_event(
+            state,
+            &StakingEvent {
+                kind: STAKING_EVENT_STAKED,
+                height: BlockHeight::from(height),
+                diamond: dianame.clone(),
+                staker: staker.clone(),
+                unlock_height: BlockHeight::from(0),
+                reward: Amount::default(),
+                shares: global.total_staked_shares.clone(),
+            },
+        );
+    }
+
+    state.set_staking_global(&global);
+    Ok(())
+}
+
+pub fn staking_apply_unstake(
+    state: &mut CoreState<'_>,
+    staker: &Address,
+    diamonds: &DiamondNameListMax200,
+    height: u64,
+) -> XRet<()> {
+    diamonds.check()?;
+    let global = state.get_staking_global();
+    let reward_index = global.global_reward_index.clone();
+
+    for dianame in diamonds.clone().into_iter() {
+        let mut diaitem = match state.diamond(&dianame) {
+            Some(d) => d,
+            None => {
+                return xerrf!("diamond {} not found", dianame.to_readable());
+            }
+        };
+        if diaitem.status != DIAMOND_STATUS_STAKED {
+            return xerrf!("diamond {} is not staked", dianame.to_readable());
+        }
+        if *staker != diaitem.address {
+            return xerrf!(
+                "diamond {} not belong to staker {}",
+                dianame.to_readable(),
+                staker
+            );
+        }
+
+        let record = match state.staking_record(&dianame) {
+            Some(r) => r,
+            None => {
+                return xerrf!(
+                    "staking record for {} not found",
+                    dianame.to_readable()
+                );
+            }
+        };
+        let stake_height = record.stake_height.uint();
+        if height < stake_height + MIN_STAKE_BLOCKS {
+            return xerrf!(
+                "diamond {} must remain staked for at least {} blocks",
+                dianame.to_readable(),
+                MIN_STAKE_BLOCKS
+            );
+        }
+
+        let reward = staking_accrued_amount(&reward_index, &record.reward_index)?;
+
+        diaitem.status = DIAMOND_STATUS_STAKING_COOLDOWN;
+        state.diamond_set(&dianame, &diaitem);
+
+        let unlock_height = height + COOLDOWN_BLOCKS;
+        let cooldown_record = StakingRecord {
+            stake_height: record.stake_height.clone(),
+            unlock_height: BlockHeight::from(unlock_height),
+            reward_index: reward_index.clone(),
+            pending_reward: reward.clone(),
+        };
+        state.staking_record_set(&dianame, &cooldown_record);
+
+        let mut global = state.get_staking_global();
+        global.total_staked_shares =
+            Uint5::from(global.total_staked_shares.uint().saturating_sub(1));
+        state.set_staking_global(&global);
+
+        let entry = StakingUnlockEntry {
+            unlock_height: BlockHeight::from(unlock_height),
+            diamond: dianame.clone(),
+            staker: staker.clone(),
+            reward: reward.clone(),
+        };
+        staking_enqueue_unlock(state, &entry)?;
+
+        staking_push_event(
+            state,
+            &StakingEvent {
+                kind: STAKING_EVENT_UNSTAKE_REQUESTED,
+                height: BlockHeight::from(height),
+                diamond: dianame.clone(),
+                staker: staker.clone(),
+                unlock_height: BlockHeight::from(unlock_height),
+                reward: entry.reward.clone(),
+                shares: Uint5::from(0),
+            },
+        );
+    }
+
+    Ok(())
+}

--- a/protocol/src/state/state.rs
+++ b/protocol/src/state/state.rs
@@ -22,6 +22,13 @@ inst_state_define!{ CoreState,
     16, diamond_owned,  Address          : DiamondOwnedForm
     17, asset,          Fold64           : AssetSmelt
 
+    /* HIP-25 staking */
+
+    18, staking_global,  Empty            : StakingGlobal
+    19, staking_record,  DiamondName      : StakingRecord
+    20, staking_unlock,  Uint5            : StakingUnlockEntry
+    21, staking_event,   Uint5            : StakingEvent
+
 }
 
 

--- a/protocol/src/tests.rs
+++ b/protocol/src/tests.rs
@@ -623,6 +623,7 @@ fn test_block_execute_must_credit_reward_and_fees_to_default_prelude() {
         id: 0,
         diamond_form: false,
         fast_sync: false,
+        staking_activation_height: 0,
     };
     let mut state_in: Box<dyn State> = Box::new(AstForkableState::default());
     {

--- a/vm/src/api/contract_sandbox_call.rs
+++ b/vm/src/api/contract_sandbox_call.rs
@@ -14,6 +14,7 @@ fn contract_sandbox_call(ctx: &ApiExecCtx, req: ApiRequest) -> ApiResponse {
             id: engcnf.chain_id,
             diamond_form: false,
             fast_sync: false,
+            staking_activation_height: engcnf.staking_activation_height,
         },
         block: BlkInfo {
             height,


### PR DESCRIPTION
## Summary

Draft port of HIP-25 v3 HACD staking for fullnodedev.

**Reference:** https://github.com/Moskyera/rust/tree/hip-25-staking @ \0.1.0-hip25-reference\

## Action mapping

 Kind | Action 

 37 | DiaStake 
 38 | DiaUnstake 

(Legacy rust fork used 34/35; fullnodedev reserves those for HIP-22 inscription.)

## Included (Phase 1-2)

- Staking types + CoreState keys 18-21
- Diamond status 4/5 (staked / cooldown)
- Stake / unstake actions
- Block-close reward distribution + unlock queue
- DiamondMint miner-share redirect to staking pool (v3 economics)
- Config: \staking_activation_height = 0\ in \[mint]\ (disabled until fork height agreed)

## Not included yet

- RPC \/query/staking/*\
- Ported integration tests from reference impl
- Mainnet activation height

## Note

Not activated on mainnet. For maintainer review  coordinate with Istanbul (765432) timing.